### PR TITLE
chore: Minor API renames

### DIFF
--- a/src/service.test.ts
+++ b/src/service.test.ts
@@ -103,8 +103,8 @@ describe("ServiceRegistry", () => {
     operation,
     abortSignal: new AbortController().signal,
     headers: {},
-    callerLinks: [{ type: "test", url: new URL("http://test") }],
-    handlerLinks: [],
+    inboundLinks: [{ type: "test", url: new URL("http://test") }],
+    outboundLinks: [],
     requestId: "test-req-id",
   });
 
@@ -170,7 +170,7 @@ describe("ServiceRegistry", () => {
       operation: "syncOp",
       abortSignal: new AbortController().signal,
       headers: {},
-      wait: 0,
+      timeoutMs: 0,
     };
     assert.rejects(() => registry.getResult(ctx, "token"), /HandlerError: Not implemented/);
     ctx.operation = "custom name";


### PR DESCRIPTION
## What changed

This PR is addressing some of the most trivial API changes discussed during review of #1. This is unlikely to trigger any 

- `callerLinks` and `handlerLinks` have been renamed to `inboundLinks` and `outboundLinks`
- `GetOperationResultContext.wait` has been renamed to `timeoutMs`
