### PR TITLE
Complete work on HandlerError

### DIFF
--- a/src/common/handler-error.test.ts
+++ b/src/common/handler-error.test.ts
@@ -1,0 +1,57 @@
+import { it, describe } from "node:test";
+import * as assert from "node:assert/strict";
+import { HandlerError } from "./index";
+
+describe("HandlerError", () => {
+  // Important: Keep these in sync with the sample code on the HandlerError class typedoc.
+  it("Can be constructed using sample code", () => {
+    let error = new HandlerError({
+      type: "BAD_REQUEST",
+      message: "Invalid input provided",
+    });
+
+    assert.equal(error.type, "BAD_REQUEST");
+    assert.equal(error.message, "Invalid input provided");
+    assert.equal(error.cause, undefined);
+    assert.equal(error.retryable, false);
+
+    error = new HandlerError({
+      type: "INTERNAL",
+      message: "Database unavailable",
+      retryable: true,
+    });
+
+    assert.equal(error.type, "INTERNAL");
+    assert.equal(error.message, "Database unavailable");
+    assert.equal(error.cause, undefined);
+    assert.equal(error.retryable, true);
+  });
+
+  it("Requires at least one of message or cause", () => {
+    // Reject if neither `message` nor `cause` is provided. This check is TS only.
+    // At runtime, we simply default error message to "Handler error"; that's better
+    // than throwing a type error, which would be masking the actual error.
+    // @ts-expect-error 2344 Should require at least one of `message` or `cause`
+    let error = new HandlerError({ type: "UNAVAILABLE" });
+    assert.equal(error.message, "Handler error");
+
+    // Accept only `message`
+    error = new HandlerError({ message: "Error message", type: "UNAVAILABLE" });
+    assert.equal(error.message, "Error message");
+
+    // Accept only `cause`
+    error = new HandlerError({ cause: new Error("Cause message"), type: "UNAVAILABLE" });
+    assert.equal(error.message, "Cause message");
+    assert.equal((error.cause as Error).message, "Cause message");
+
+    // FIXME: Waiting for final confirmation on desired behavior.
+    // Accept both `message` and `cause`
+    error = new HandlerError({
+      message: "Error message",
+      cause: new Error("Cause message"),
+      type: "UNAVAILABLE",
+    });
+    assert.equal(error.message, "Error message: Cause message");
+    assert.equal((error.cause as Error).message, "Cause message");
+  });
+});

--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -2,43 +2,72 @@ import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
 
 /**
  * An error type associated with a {@link HandlerError}, defined according to the Nexus specification.
- * Only the types defined as consts in this package are valid. Do not use other values. See each type's details below:
  *
- * BAD_REQUEST - The server cannot or will not process the request due to an apparent client error. Clients should not
- * retry this request unless advised otherwise.
- *
- * UNAUTHENTICATED - The client did not supply valid authentication credentials for this request. Clients should not
- * retry this request unless advised otherwise.
- *
- * UNAUTHORIZED - The caller does not have permission to execute the specified operation. Clients should not retry this
- * request unless advised otherwise.
- *
- * NOT_FOUND - The requested resource could not be found but may be available in the future. Clients should not retry
- * this request unless advised otherwise.
- *
- * RESOURCE_EXHAUSTED - Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
- * is out of space. Subsequent requests by the client are permissible.
- *
- * INTERNAL - An internal error occured. Subsequent requests by the client are permissible.
- *
- * NOT_IMPLEMENTED - The server either does not recognize the request method, or it lacks the ability to fulfill the
- * request. Clients should not retry this request unless advised otherwise.
- *
- * UNAVAILABLE - The service is currently unavailable. Subsequent requests by the client are permissible.
- *
- * UPSTREAM_TIMEOUT - Used by gateways to report that a request to an upstream server has timed out. Subsequent
- * requests by the client are permissible.
+ * @experimental
  */
-export type HandlerErrorType =
-  | "BAD_REQUEST"
-  | "UNAUTHENTICATED"
-  | "UNAUTHORIZED"
-  | "NOT_FOUND"
-  | "RESOURCE_EXHAUSTED"
-  | "INTERNAL"
-  | "NOT_IMPLEMENTED"
-  | "UNAVAILABLE"
-  | "UPSTREAM_TIMEOUT";
+export type HandlerErrorType = (typeof HandlerErrorType)[keyof typeof HandlerErrorType];
+export const HandlerErrorType = {
+  /**
+   * The handler cannot or will not process the request due to an apparent client error.
+   *
+   * Clients should not retry this request unless advised otherwise.
+   */
+  BAD_REQUEST: "BAD_REQUEST",
+
+  /**
+   * The client did not supply valid authentication credentials for this request.
+   *
+   * Clients should not retry this request unless advised otherwise.
+   */
+  UNAUTHENTICATED: "UNAUTHENTICATED",
+
+  /**
+   * The caller does not have permission to execute the specified operation.
+   *
+   * Clients should not retry this request unless advised otherwise.
+   */
+  UNAUTHORIZED: "UNAUTHORIZED",
+
+  /**
+   * The requested resource could not be found but may be available in the future.
+   */
+  NOT_FOUND: "NOT_FOUND",
+
+  /**
+   * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
+   * is out of space.
+   *
+   * Subsequent requests by the client are permissible.
+   */
+  RESOURCE_EXHAUSTED: "RESOURCE_EXHAUSTED",
+
+  /**
+   * An internal error occured.
+   *
+   * Subsequent requests by the client are permissible.
+   */
+  INTERNAL: "INTERNAL",
+
+  /**
+   * The server either does not recognize the request method, or it lacks the ability to fulfill the
+ * request. Clients should not retry this request unless advised otherwise.
+   */
+  NOT_IMPLEMENTED: "NOT_IMPLEMENTED",
+
+  /**
+   * The service is currently unavailable.
+   *
+   * Subsequent requests by the client are permissible.
+   */
+  UNAVAILABLE: "UNAVAILABLE",
+
+  /**
+   * Used by gateways to report that a request to an upstream server has timed out.
+   *
+   * Subsequent requests by the client are permissible.
+ */
+  UPSTREAM_TIMEOUT: "UPSTREAM_TIMEOUT",
+} as const;
 
 /**
  * Options for constructing a {@link HandlerError} from a message, type, and a retryable flag.

--- a/src/index.doc.ts
+++ b/src/index.doc.ts
@@ -1,1 +1,4 @@
 export * from "./index";
+
+// These are not meant to be public, but required to properly generate docs.
+export * from "./internal/types";

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,2 +1,3 @@
+import "./common/handler-error.test.js";
 import "./internal/symbol-instanceof.test.js";
 import "./service.test.js";

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,0 +1,60 @@
+// FIXME: Prune unneeded types once we've settled the question of HandlerErrorOptions.
+
+/**
+ * A utility type that requires at least one of the specified keys to be present.
+ *
+ * @template T - The base type
+ * @template K - The keys that should have at least one present
+ *
+ * @example
+ * ```ts
+ *   interface Options {
+ *     message?: string;
+ *     cause?: unknown;
+ *     type: string;
+ *   }
+ *
+ *   // This ensures at least one of 'message' or 'cause' is present
+ *   type ValidOptions = RequireAtLeastOneOf<Options, 'message' | 'cause'>;
+ * ```
+ *
+ * @internal
+ */
+export type RequireAtLeastOneOf<T, K extends keyof T> = {
+  [P in K]-?: Required<Pick<T, P>> & Partial<Omit<Pick<T, K>, P>>;
+}[K] &
+  Omit<T, K>;
+
+/**
+ * A utility type that requires exactly one of the specified keys to be present.
+ *
+ * @template T - The base type
+ * @template K - The keys of which exactly one should be present
+ *
+ * @example
+ * ```ts
+ *   interface Options {
+ *     message?: string;
+ *     cause?: unknown;
+ *     type: string;
+ *   }
+ *
+ *   // This ensures either 'message' or 'cause' is present, but not both
+ *   type ValidOptions = RequireExactlyOne<Options, 'message' | 'cause'>;
+ * ```
+ *
+ * @internal
+ */
+export type RequireExactlyOne<T, K extends keyof T> = {
+  [P in K]-?: Required<Pick<T, P>> & Forbid<Exclude<K, P>>;
+}[K] &
+  Omit<T, K>;
+
+/**
+ * A utility type that forbids the specified properties
+ *
+ * @template K - The keys to forbid
+ *
+ * @internal
+ */
+export type Forbid<K extends string | number | symbol> = Record<K, never>;


### PR DESCRIPTION
## What changed

This is all about `HandlerError`:
- Docs
- Tests
- Converted `HandlerErrorType` to "const object of strings + mapped type" form
- Accept both `cause` and `message` at the same time (FIXME: it's no longer clear this is what we want, waiting for final team decision)
- Add `retryableOverride`, and compute effective retryability
