### PR TITLE
Complete work on OperationError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/node": "^18.0.0",
         "eslint": "^9.31.0",
         "prettier": "^3.6.2",
+        "shx": "^0.4.0",
         "typedoc": "^0.28.7",
         "typedoc-github-theme": "^0.3.0",
         "typescript": "^5.8.3",
@@ -817,6 +818,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -998,6 +1009,98 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1123,6 +1226,29 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1166,6 +1292,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -1203,6 +1342,32 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1234,6 +1399,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/isexe": {
@@ -1403,6 +1578,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1416,6 +1601,46 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1433,6 +1658,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/p-limit": {
@@ -1500,6 +1735,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1537,6 +1779,17 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -1579,6 +1832,39 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -1661,6 +1947,59 @@
         "node": ">=8"
       }
     },
+    "node_modules/shelljs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.9.2.tgz",
+      "integrity": "sha512-S3I64fEiKgTZzKCC46zT/Ib9meqofLrQVbpSswtjFfAVDW+AZ54WTnAM/3/yENoxz/V1Cy6u3kiiEbQ4DNphvw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "execa": "^1.0.0",
+        "fast-glob": "^3.3.2",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/shx": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.4.0.tgz",
+      "integrity": "sha512-Z0KixSIlGPpijKgcH6oCMCbltPImvaKy0sGH8AkLRXw1KyzpKtaCTizP2xen+hNDqVF4xxgvA0KXSb9o4Q6hnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.8",
+        "shelljs": "^0.9.2"
+      },
+      "bin": {
+        "shx": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1685,6 +2024,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/to-regex-range": {
@@ -1876,6 +2228,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -28,13 +28,15 @@
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --check .",
-    "format:fix": "prettier --write ."
+    "format:fix": "prettier --write .",
+    "clean": "shx rm -rf lib tsconfig.tsbuildinfo"
   },
   "devDependencies": {
     "@eslint/js": "^9.31.0",
     "@types/node": "^18.0.0",
     "eslint": "^9.31.0",
     "prettier": "^3.6.2",
+    "shx": "^0.4.0",
     "typedoc": "^0.28.7",
     "typedoc-github-theme": "^0.3.0",
     "typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "build:docs": "typedoc src/index.doc.ts --plugin typedoc-github-theme",
-    "test": "node lib/index.test.js",
+    "test": "node --test",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --check .",

--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -53,35 +53,12 @@ export class HandlerError extends Error {
    *
    * @experimental
    */
-  constructor(
-    type: HandlerErrorType,
-    message?: string | undefined,
-    options?: Omit<HandlerErrorOptions, "message">,
-  ) {
+  constructor(type: HandlerErrorType, message?: string | undefined, options?: HandlerErrorOptions) {
     const actualMessage = message || `Handler error: ${type}`;
 
     super(actualMessage, { cause: options?.cause });
     this.type = type;
     this.retryableOverride = options?.retryableOverride;
-  }
-
-  /**
-   * Wraps an error in a {@link HandlerError}.
-   *
-   * This is a convenience method to create an {@link HandlerError} that simply contains an
-   * existing error.
-   *
-   * @param type - The type of the error.
-   * @param cause - The cause of the error.
-   * @returns A new {@link HandlerError} instance wrapping the error.
-   */
-  public static wrap(
-    type: HandlerErrorType,
-    cause: unknown,
-    options?: Omit<HandlerErrorOptions, "cause">,
-  ): HandlerError {
-    const { message, ...rest } = options ?? {};
-    return new HandlerError(type, message, { ...rest, cause });
   }
 
   /**
@@ -127,11 +104,6 @@ injectSymbolBasedInstanceOf(HandlerError, "HandlerError");
  * @inline
  */
 export interface HandlerErrorOptions {
-  /**
-   * Message of the error.
-   */
-  message?: string | undefined;
-
   /**
    * Underlying cause of the error.
    */

--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -53,7 +53,11 @@ export class HandlerError extends Error {
    *
    * @experimental
    */
-  constructor(type: HandlerErrorType, message?: string | undefined, options?: HandlerErrorOptions) {
+  constructor(
+    type: HandlerErrorType,
+    message?: string | undefined,
+    options?: Omit<HandlerErrorOptions, "message">,
+  ) {
     const actualMessage = message || `Handler error: ${type}`;
 
     super(actualMessage, { cause: options?.cause });
@@ -76,7 +80,8 @@ export class HandlerError extends Error {
     cause: unknown,
     options?: Omit<HandlerErrorOptions, "cause">,
   ): HandlerError {
-    return new HandlerError(type, undefined, { ...options, cause });
+    const { message, ...rest } = options ?? {};
+    return new HandlerError(type, message, { ...rest, cause });
   }
 
   /**
@@ -122,6 +127,11 @@ injectSymbolBasedInstanceOf(HandlerError, "HandlerError");
  * @inline
  */
 export interface HandlerErrorOptions {
+  /**
+   * Message of the error.
+   */
+  message?: string | undefined;
+
   /**
    * Underlying cause of the error.
    */

--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -9,7 +9,7 @@ import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
  * Example:
  *
  * ```ts
- *     import { HandlerError } from "@nexus-rpc/sdk-typescript";
+ *     import { HandlerError } from "nexus-rpc";
  *
  *     // Throw a bad request error
  *     throw new HandlerError("BAD_REQUEST", "Invalid input provided");
@@ -64,7 +64,8 @@ export class HandlerError extends Error {
   /**
    * Wraps an error in a {@link HandlerError}.
    *
-   * This is a convenience method to wrap an existing error into a {@link HandlerError}.
+   * This is a convenience method to create an {@link HandlerError} that simply contains an
+   * existing error.
    *
    * @param type - The type of the error.
    * @param cause - The cause of the error.

--- a/src/common/operation-error.test.ts
+++ b/src/common/operation-error.test.ts
@@ -3,53 +3,80 @@ import * as assert from "node:assert/strict";
 import { OperationError } from "./index";
 
 describe("OperationError", () => {
-  it("Can be constructed", () => {
-    const error = new OperationError({
-      state: "failed",
-      cause: new Error("Service unavailable"),
-    });
+  // Important: Keep these in sync with the sample code on the OperationError class typedoc.
+  it("Can be constructed using sample code", () => {
+    {
+      const error = new OperationError("failed", "Not enough inventory");
 
-    assert.equal(error.message, "Operation failed");
-    assert.deepEqual(error.cause, new Error("Service unavailable"));
-    assert.equal(error.state, "failed");
+      assert.equal(error.message, "Not enough inventory");
+      assert.equal(error.cause, undefined);
+      assert.equal(error.state, "failed");
+    }
+
+    {
+      const cause = new Error("Cause message");
+      const error = new OperationError("failed", "Not enough inventory", { cause });
+
+      assert.equal(error.message, "Not enough inventory");
+      assert.deepEqual(error.cause, new Error("Cause message"));
+      assert.equal(error.state, "failed");
+    }
+
+    {
+      const error = new OperationError("canceled", "User canceled the operation");
+
+      assert.equal(error.message, "User canceled the operation");
+      assert.equal(error.cause, undefined);
+      assert.equal(error.state, "canceled");
+    }
   });
 
-  it("Requires cause", () => {
-    assert.throws(
-      () => {
-        // @ts-expect-error - Property cause is missing ...
-        new OperationError({ state: "failed" });
-      },
-      {
-        name: "TypeError",
-        message: "OperationError's cause is required and must be an object; got: 'undefined'",
-      },
-    );
+  it("Properly handles all combinations of message and cause", () => {
+    {
+      // Use the default message if neither `message` nor `cause` is provided (canceled)
+      const error = new OperationError("canceled");
+      assert.equal(error.message, "Operation canceled");
+      assert.equal(error.cause, undefined);
+    }
+
+    {
+      // Use the default message if neither `message` nor `cause` is provided (failed)
+      const error = new OperationError("failed");
+      assert.equal(error.message, "Operation failed");
+      assert.equal(error.cause, undefined);
+    }
+
+    {
+      // Accept only `message`
+      const error = new OperationError("failed", "Error message");
+      assert.equal(error.message, "Error message");
+      assert.equal(error.cause, undefined);
+    }
+
+    {
+      // Accept only `cause`
+      const cause = new Error("Service unavailable");
+      const error = new OperationError("failed", undefined, { cause });
+
+      assert.equal(error.message, "Operation failed");
+      assert.deepEqual(error.cause, cause);
+    }
+
+    {
+      // Accept both `message` and `cause`.
+      const cause = new Error("Service unavailable");
+      const error = new OperationError("failed", "Error message", { cause });
+
+      assert.equal(error.message, "Error message");
+      assert.deepEqual(error.cause, cause);
+    }
   });
 
   it("Requires valid state", () => {
-    assert.throws(
-      () => {
-        // @ts-expect-error - Property ... is missing in type ...
-        new OperationError({ cause: new Error("Service unavailable") });
-      },
-      {
-        name: "TypeError",
-        message:
-          "OperationError's state is required and must be either 'canceled' or 'failed'; got: 'undefined'",
-      },
-    );
+    // @ts-expect-error - Argument ... is not assignable to type ...
+    new OperationError(undefined, "x");
 
-    assert.throws(
-      () => {
-        // @ts-expect-error - Type ... is not assignable to type ...
-        new OperationError({ cause: new Error("Service unavailable"), state: "invalid" });
-      },
-      {
-        name: "TypeError",
-        message:
-          "OperationError's state is required and must be either 'canceled' or 'failed'; got: 'invalid'",
-      },
-    );
+    // @ts-expect-error - Argument ... is not assignable to type ...
+    new OperationError("invalid", "x");
   });
 });

--- a/src/common/operation-error.test.ts
+++ b/src/common/operation-error.test.ts
@@ -1,0 +1,55 @@
+import { it, describe } from "node:test";
+import * as assert from "node:assert/strict";
+import { OperationError } from "./index";
+
+describe("OperationError", () => {
+  it("Can be constructed", () => {
+    const error = new OperationError({
+      state: "failed",
+      cause: new Error("Service unavailable"),
+    });
+
+    assert.equal(error.message, "Operation failed");
+    assert.deepEqual(error.cause, new Error("Service unavailable"));
+    assert.equal(error.state, "failed");
+  });
+
+  it("Requires cause", () => {
+    assert.throws(
+      () => {
+        // @ts-expect-error - Property cause is missing ...
+        new OperationError({ state: "failed" });
+      },
+      {
+        name: "TypeError",
+        message: "OperationError's cause is required and must be an object; got: 'undefined'",
+      },
+    );
+  });
+
+  it("Requires valid state", () => {
+    assert.throws(
+      () => {
+        // @ts-expect-error - Property ... is missing in type ...
+        new OperationError({ cause: new Error("Service unavailable") });
+      },
+      {
+        name: "TypeError",
+        message:
+          "OperationError's state is required and must be either 'canceled' or 'failed'; got: 'undefined'",
+      },
+    );
+
+    assert.throws(
+      () => {
+        // @ts-expect-error - Type ... is not assignable to type ...
+        new OperationError({ cause: new Error("Service unavailable"), state: "invalid" });
+      },
+      {
+        name: "TypeError",
+        message:
+          "OperationError's state is required and must be either 'canceled' or 'failed'; got: 'invalid'",
+      },
+    );
+  });
+});

--- a/src/common/operation-error.ts
+++ b/src/common/operation-error.ts
@@ -44,29 +44,13 @@ export class OperationError extends Error {
   constructor(
     state: OperationErrorState,
     message?: string | undefined,
-    options?: Omit<OperationErrorOptions, "message">,
+    options?: OperationErrorOptions,
   ) {
     const defaultMessage = state === "canceled" ? `Operation canceled` : `Operation failed`;
     const actualMessage = message || defaultMessage;
 
     super(actualMessage, { cause: options?.cause });
     this.state = state;
-  }
-
-  /**
-   * Wraps an error in a {@link OperationError}.
-   *
-   * This is a convenience method to create an {@link OperationError} that simply contains an
-   * existing error.
-   *
-   * @experimental
-   */
-  public static wrap(
-    state: OperationErrorState,
-    cause: Error,
-    options?: Omit<OperationErrorOptions, "cause">,
-  ): OperationError {
-    return new OperationError(state, options?.message, { cause });
   }
 }
 
@@ -79,11 +63,6 @@ injectSymbolBasedInstanceOf(OperationError, "OperationError");
  * @inline
  */
 export interface OperationErrorOptions {
-  /**
-   * Message of the error.
-   */
-  message?: string | undefined;
-
   /**
    * Underlying cause of the error.
    */

--- a/src/common/operation-error.ts
+++ b/src/common/operation-error.ts
@@ -34,10 +34,17 @@ export class OperationError extends Error {
    */
   declare public readonly cause: Error;
 
+  /**
+   * Constructs a new {@link OperationError}.
+   *
+   * @param state - The state of the operation.
+   * @param message - The message of the error.
+   * @param options - Extra options for the error, e.g. the cause.
+   */
   constructor(
     state: OperationErrorState,
     message?: string | undefined,
-    options?: OperationErrorOptions,
+    options?: Omit<OperationErrorOptions, "message">,
   ) {
     const defaultMessage = state === "canceled" ? `Operation canceled` : `Operation failed`;
     const actualMessage = message || defaultMessage;
@@ -59,7 +66,7 @@ export class OperationError extends Error {
     cause: Error,
     options?: Omit<OperationErrorOptions, "cause">,
   ): OperationError {
-    return new OperationError(state, undefined, { ...options, cause });
+    return new OperationError(state, options?.message, { cause });
   }
 }
 
@@ -73,9 +80,14 @@ injectSymbolBasedInstanceOf(OperationError, "OperationError");
  */
 export interface OperationErrorOptions {
   /**
+   * Message of the error.
+   */
+  message?: string | undefined;
+
+  /**
    * Underlying cause of the error.
    */
-  cause: Error;
+  cause?: Error | undefined;
 }
 
 /**
@@ -84,5 +96,6 @@ export interface OperationErrorOptions {
  * This is a subset of {@link OperationState}.
  *
  * @experimental
+ * @inline
  */
 export type OperationErrorState = "failed" | "canceled";

--- a/src/common/operation-error.ts
+++ b/src/common/operation-error.ts
@@ -9,7 +9,7 @@ import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
  * Example:
  *
  * ```ts
- *     import { OperationError } from "@nexus-rpc/sdk-typescript";
+ *     import { OperationError } from "nexus-rpc";
  *
  *     // Throw a failed operation error
  *     throw new OperationError("failed", "Not enough inventory");
@@ -47,25 +47,19 @@ export class OperationError extends Error {
   }
 
   /**
-   * Create a new {@link OperationError} representing a failed operation.
+   * Wraps an error in a {@link OperationError}.
    *
-   * This is a convenience method to create an {@link OperationError} for a failed operation.
-   *
-   * @experimental
-   */
-  public static failed(cause: Error): OperationError {
-    return new OperationError("failed", undefined, { cause });
-  }
-
-  /**
-   * Create a new {@link OperationError} representing a canceled operation.
-   *
-   * This is a convenience method to create an {@link OperationError} for a canceled operation.
+   * This is a convenience method to create an {@link OperationError} that simply contains an
+   * existing error.
    *
    * @experimental
    */
-  public static canceled(cause: Error): OperationError {
-    return new OperationError("canceled", undefined, { cause });
+  public static wrap(
+    state: OperationErrorState,
+    cause: Error,
+    options?: Omit<OperationErrorOptions, "cause">,
+  ): OperationError {
+    return new OperationError(state, undefined, { ...options, cause });
   }
 }
 

--- a/src/common/operation-error.ts
+++ b/src/common/operation-error.ts
@@ -1,39 +1,99 @@
 import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
 
 /**
- * Options for constructing an {@link OperationError} from a message and operation state.
+ * Options for constructing an {@link OperationError}.
+ *
+ * @experimental
+ * @inline
  */
-export interface OperationErrorMessageOptions {
-  /** Error message. */
-  message: string;
-
-  /** State of the operation. */
+export interface OperationErrorOptions {
+  /**
+   * State of the operation.
+   */
   state: "canceled" | "failed";
-}
 
-/**
- * Options for constructing an {@link OperationError} from an underlying cause and operation state.
- */
-export interface OperationErrorCauseOptions extends ErrorOptions {
-  /** State of the operation. */
-  state: "canceled" | "failed";
+  /**
+   * Underlying cause of the error.
+   */
+  cause: Error;
 }
-
-/**
- * Options for constructing an {@link OperationError} from either a message or an underlying cause.
- */
-export type OperationErrorOptions = OperationErrorMessageOptions | OperationErrorCauseOptions;
 
 /**
  * An error that represents "failed" and "canceled" operation results.
+ *
+ * @experimental
  */
+// XXX: Go: OperationError (nexus/api.go)
+// XXX: Java: OperationException (java.io.nexusrpc.OperationException)
+// XXX: Python: OperationError (nexusrpc/_common.py)
+// XXX: Note the absence of `message`. This is in line with all reference SDKs.
+// XXX: Python has one, which is incorrect. We may change this across the board in the future, but not now.
 export class OperationError extends Error {
-  /** State of the operation. */
+  /**
+   * State of the operation.
+   */
   public readonly state: "canceled" | "failed";
 
+  /**
+   * The error that resulted in this operation error.
+   */
+  declare public readonly cause: Error;
+
   constructor(options: OperationErrorOptions) {
-    super((options as any).message, options as any as ErrorOptions);
+    if (options.state !== "canceled" && options.state !== "failed") {
+      throw new TypeError(
+        `OperationError's state is required and must be either 'canceled' or 'failed'; got: '${options.state}'`,
+      );
+    }
+
+    if (typeof options.cause !== "object" || options.cause === null) {
+      throw new TypeError(
+        `OperationError's cause is required and must be an object; got: '${options.cause}'`,
+      );
+    }
+
+    // According to the spec, OperationError really doesn't have a message of its own,
+    // but we make one, because it is generally expected in JS that Error.message is set.
+    const message = options.state === "failed" ? `Operation failed` : `Operation canceled`;
+
+    super(message, { cause: options.cause });
     this.state = options.state;
+  }
+
+  /**
+   * Create a new {@link OperationError} representing a failed operation.
+   *
+   * This is a convenience method. It is equivalent to:
+   *
+   * ```ts
+   * new OperationError({ state: "failed", cause });
+   * ```
+   *
+   * @experimental
+   */
+  public static failure(cause: Error): OperationError {
+    return new OperationError({
+      state: "failed",
+      cause,
+    });
+  }
+
+  /**
+   * Create a new {@link OperationError} representing a canceled operation.
+   *
+   * This is a convenience method. It is equivalent to:
+   *
+   * ```ts
+   * new OperationError({ state: "canceled", cause });
+   * ```
+   *
+   * @experimental
+   */
+  public static canceled(cause: Error): OperationError {
+    return new OperationError({
+      state: "canceled",
+      cause,
+    });
   }
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,0 @@
-import "./common/handler-error.test.js";
-import "./common/operation-error.test.js";
-import "./internal/symbol-instanceof.test.js";
-import "./service.test.js";

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,3 +1,4 @@
 import "./common/handler-error.test.js";
+import "./common/operation-error.test.js";
 import "./internal/symbol-instanceof.test.js";
 import "./service.test.js";


### PR DESCRIPTION
## What changed

This is all about `OperationError`:

- Remove possibility of passing in a message on constructor (based on alignment with other SDKs + team decision)
- Add runtime validations for pure-JS usages
- Helper function constructors (alignment with other SDKs)
- Tests