### PR TITLE
Restructure serialization APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prepare": "npm run build",
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
-    "build:docs": "typedoc src/index.doc.ts --plugin typedoc-github-theme",
+    "build:docs": "typedoc src --plugin typedoc-github-theme",
     "test": "node --test",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",

--- a/src/handler/service-registry.ts
+++ b/src/handler/service-registry.ts
@@ -1,5 +1,5 @@
 import { HandlerError, OperationInfo } from "../common";
-import { LazyValue } from "../serializer";
+import { LazyValue } from "../serialization";
 import { HandlerStartOperationResult } from "./start-operation-result";
 import {
   OperationContext,

--- a/src/index.doc.ts
+++ b/src/index.doc.ts
@@ -1,1 +1,0 @@
-export * from "./index";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./common";
 export * from "./service";
 export * from "./handler";
-
-export { LazyValue, type Content, type Serializer } from "./serializer";
+export * from "./serialization";

--- a/src/serialization/content.ts
+++ b/src/serialization/content.ts
@@ -1,0 +1,18 @@
+/**
+ * A container for a map of headers and a byte array of data.
+ *
+ * It is used by the SDK's {@link Serializer} interface implementations.
+ */
+export interface Content {
+  /**
+   * Header that should include information on how to deserialize this content.
+   * Headers constructed by the framework always have lower case keys.
+   * User provided keys are considered case-insensitive by the framework.
+   */
+  headers: Record<string, string>;
+
+  /**
+   * Request or response data. May be undefined for empty data.
+   */
+  data?: Uint8Array;
+}

--- a/src/serialization/index.ts
+++ b/src/serialization/index.ts
@@ -1,0 +1,3 @@
+export { LazyValue } from "./lazy-value";
+export { type Serializer } from "./serializer";
+export { type Content } from "./content";

--- a/src/serialization/lazy-value.ts
+++ b/src/serialization/lazy-value.ts
@@ -1,4 +1,5 @@
-import { injectSymbolBasedInstanceOf } from "./internal/symbol-instanceof";
+import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
+import { Serializer } from "./serializer";
 
 /**
  * A container for a value encoded in an underlying stream.
@@ -15,7 +16,9 @@ export class LazyValue {
      */
     readonly headers: Record<string, string>,
 
-    /** ReadableStream that contains request or response data. May be undefined for empty data. */
+    /**
+     * ReadableStream that contains request or response data. May be undefined for empty data.
+     */
     public readonly stream?: ReadableStream<Uint8Array>,
   ) {}
 
@@ -50,31 +53,3 @@ export class LazyValue {
 }
 
 injectSymbolBasedInstanceOf(LazyValue, "LazyValue");
-
-/**
- * A container for a map of headers and a byte array of data.
- *
- * It is used by the SDK's {@link Serializer} interface implementations.
- */
-export interface Content {
-  /**
-   * Header that should include information on how to deserialize this content.
-   * Headers constructed by the framework always have lower case keys.
-   * User provided keys are considered case-insensitive by the framework.
-   */
-  headers: Record<string, string>;
-
-  /** Request or response data. May be undefined for empty data. */
-  data?: Uint8Array;
-}
-
-/**
- * Serializer is used by the framework to serialize/deserialize input and output.
- */
-export interface Serializer {
-  /** Serialize encodes a value into a {@link Content}. */
-  serialize(value: unknown): Content;
-
-  /** Deserialize decodes a {@link Content} into a value. */
-  deserialize<T = unknown>(content: Content): T;
-}

--- a/src/serialization/serializer.ts
+++ b/src/serialization/serializer.ts
@@ -1,0 +1,16 @@
+import { Content } from "./content";
+
+/**
+ * Serializer is used by the framework to serialize/deserialize input and output.
+ */
+export interface Serializer {
+  /**
+   * Serialize encodes a value into a {@link Content}.
+   */
+  serialize(value: unknown): Content;
+
+  /**
+   * Deserialize decodes a {@link Content} into a value.
+   */
+  deserialize<T = unknown>(content: Content): T;
+}


### PR DESCRIPTION
## What changed

- Split `serializer.ts` into more targeted files inside `serialization/`.

## Why?

- Following the same structure introduced previously for `common/`.
- There will be more commits affecting this directory, later on.