### PR TITLE
Formalize ServiceDefinition and OperationDefinition

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,5 +1,5 @@
 import { HandlerError, Link, OperationInfo } from "./common";
-import { Operation, OperationMap, Service } from "./service";
+import { OperationDefinition, OperationMap, ServiceDefinition } from "./service";
 import { LazyValue } from "./serializer";
 
 /**
@@ -158,7 +158,7 @@ export type SyncOperationHandler<I, O> = (ctx: StartOperationContext, input: I) 
  * A type that defines a handler for a given operation.
  */
 export type OperationHandlerFor<T> =
-  T extends Operation<infer I, infer O>
+  T extends OperationDefinition<infer I, infer O>
     ? OperationHandler<I, O> | SyncOperationHandler<I, O>
     : never;
 
@@ -172,7 +172,8 @@ export type ServiceHandlerFor<T extends OperationMap = OperationMap> = {
 /**
  * A {@link Service} that includes a collection of handlers for its operations.
  */
-export interface ServiceHandler<T extends OperationMap = OperationMap> extends Service<T> {
+export interface ServiceHandler<T extends OperationMap = OperationMap>
+  extends ServiceDefinition<T> {
   handlers: ServiceHandlerFor<T>;
 }
 
@@ -180,7 +181,7 @@ export interface ServiceHandler<T extends OperationMap = OperationMap> extends S
  * Constructs a service handler for a given service contract.
  */
 export function serviceHandler<T extends OperationMap>(
-  service: Service<T>,
+  service: ServiceDefinition<T>,
   handlers: ServiceHandlerFor<T>,
 ): ServiceHandler<T> {
   const ops = new Set<string>();

--- a/src/internal/object-utils.ts
+++ b/src/internal/object-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Creates a new object by mapping all string properties (keys and values) of an existing object
+ * through a mapper function.
+ *
+ * @param obj - The source object, whose properties will be mapped.
+ * @param fn - The mapper function.
+ *
+ * @returns A new object with the properties mapped to the new type.
+ */
+export function mapKeyValues<T extends Record<string, any>, U>(
+  obj: T,
+  fn: (key: keyof T & string, value: T[keyof T & string]) => U,
+): Record<keyof T, U> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key, fn(key, value)]),
+  ) as Record<keyof T, U>;
+}

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,0 +1,17 @@
+/**
+ * Flatten the type output to improve type hints shown in editors.
+ *
+ * This utility type forces TypeScript into performing a "flattening" operation at a specific point
+ * in the type evaluation tree, which may sometime result in more readable type hints in editors.
+ *
+ * See https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ */
+export type Simplify<T> = { [K in keyof T]: T[K] } & {};
+
+/**
+ * Defines a type that is a union of literal string values, but that also accepts any other string,
+ * without sacrificing auto-completion in TypeScript editors for the literal type part of the union.
+ *
+ * See https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
+ */
+export type LiteralStringUnion<T> = T | (string & {});

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,6 +1,6 @@
 export {
-  type Service,
-  type Operation,
+  type ServiceDefinition,
+  type OperationDefinition,
   type OperationMap,
   type OperationInput,
   type OperationOutput,

--- a/src/service/service.test.ts
+++ b/src/service/service.test.ts
@@ -8,34 +8,14 @@ const myService = nexus.service("service name", {
   fullOp: nexus.operation<number, number>({ name: "custom name" }),
 });
 
-describe("OperationKey", () => {
-  it("infers operation keys", () => {
-    const _k1: nexus.OperationKey<(typeof myService)["operations"]> = "syncOp";
-    const _k2: nexus.OperationKey<(typeof myService)["operations"]> = "fullOp";
-  });
-});
-
-describe("OperationInput", () => {
-  it("infers operation input type", () => {
-    const _i1: nexus.OperationInput<(typeof myService)["operations"]["syncOp"]> = "string";
-    const _i2: nexus.OperationInput<(typeof myService)["operations"]["fullOp"]> = 1;
-  });
-});
-
-describe("OperationOutput", () => {
-  it("infers operation Output type", () => {
-    const _o1: nexus.OperationOutput<(typeof myService)["operations"]["syncOp"]> = "string";
-    const _o2: nexus.OperationOutput<(typeof myService)["operations"]["fullOp"]> = 1;
-  });
-});
-
-describe("service", () => {
+describe("service and operation", () => {
   it("throws when registering a service with an empty name", () => {
     assert.throws(
       () => nexus.service("", {}),
       /TypeError: Service name must be a non-empty string/,
     );
   });
+
   it("throws when registering a duplicate operation", () => {
     assert.throws(
       () =>
@@ -43,7 +23,72 @@ describe("service", () => {
           syncOp: nexus.operation<string, string>(),
           syncOpAlias: nexus.operation<string, string>({ name: "syncOp" }),
         }),
-      /TypeError: Duplicate operation definition for syncOp/,
+      /TypeError: Duplicate operation definition for name: 'syncOp'/,
     );
   });
 });
+
+describe("Mapped type `OperationKey`", () => {
+  it("infers operation keys", () => {
+    type Actual = nexus.OperationKey<(typeof myService)["operations"]>;
+    type Expected = "syncOp" | "fullOp";
+    somethingOfType<Actual>() satisfies Expected;
+    somethingOfType<Expected>() satisfies Actual;
+  });
+});
+
+describe("Mapped type `OperationInput`", () => {
+  it("infers operation input type", () => {
+    {
+      type Actual = nexus.OperationInput<(typeof myService)["operations"]["syncOp"]>;
+      type Expected = string;
+      somethingOfType<Actual>() satisfies Expected;
+      somethingOfType<Expected>() satisfies Actual;
+    }
+    {
+      type Actual = nexus.OperationInput<(typeof myService)["operations"]["fullOp"]>;
+      type Expected = number;
+      somethingOfType<Actual>() satisfies Expected;
+      somethingOfType<Expected>() satisfies Actual;
+    }
+  });
+});
+
+describe("Mapped type `OperationOutput`", () => {
+  it("infers operation Output type", () => {
+    {
+      type Actual = nexus.OperationOutput<(typeof myService)["operations"]["syncOp"]>;
+      type Expected = string;
+      somethingOfType<Actual>() satisfies Expected;
+      somethingOfType<Expected>() satisfies Actual;
+    }
+    {
+      type Actual = nexus.OperationOutput<(typeof myService)["operations"]["fullOp"]>;
+      type Expected = number;
+      somethingOfType<Actual>() satisfies Expected;
+      somethingOfType<Expected>() satisfies Actual;
+    }
+  });
+});
+
+/**
+ * A utility function that pretends to return something of type `T`.
+ *
+ * This is meant to be used to simplify writing TypeScript type assertion tests.
+ *
+ * For example, to test that a given type evaluates exactly to the expected type, one can do:
+ *
+ * ```ts
+ *   {
+ *     type Actual = nexus.OperationKey<(typeof myService)["operations"]>;
+ *     type Expected = "syncOp" | "fullOp";
+ *     somethingOfType<Actual>() satisfies Expected;
+ *     somethingOfType<Expected>() satisfies Actual;
+ *   }
+ * ```
+ *
+ * If the types are not assignable, TypeScript will produce a compile-time error.
+ */
+export function somethingOfType<T>(): T {
+  return undefined as unknown as T;
+}


### PR DESCRIPTION
## What changed

This completes the work on `service` APIs.

- Rename `Service` and `ServiceDefinition`, and `Operation` to `OperationDefinition`. This aligns with other SDKs, and formalize the intent that these should provide isolation between how services are _defined_ (e.g. the `service` and `operation` functions at this time, but also other approaches that will be added in the future) and whatever else that use those definitions (e.g. handlers, client, and more in the future).
- Move service definition validation logic to a distinct `validateServiceDefinition` function, so that it can be reused elsewhere in the future.
- Other minor refactor.