### PR TITLE
Apply @experimental consistently and fix typedoc links syntax

### DIFF
--- a/src/common/operation-error.ts
+++ b/src/common/operation-error.ts
@@ -40,6 +40,8 @@ export class OperationError extends Error {
    * @param state - The state of the operation.
    * @param message - The message of the error.
    * @param options - Extra options for the error, e.g. the cause.
+   *
+   * @experimental
    */
   constructor(
     state: OperationErrorState,

--- a/src/common/operation-still-running-error.ts
+++ b/src/common/operation-still-running-error.ts
@@ -6,6 +6,9 @@ import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
  * @experimental
  */
 export class OperationStillRunningError extends Error {
+  /**
+   * @experimental
+   */
   constructor() {
     super("Operation still running");
   }

--- a/src/handler/operation-context.ts
+++ b/src/handler/operation-context.ts
@@ -2,23 +2,35 @@ import { Link } from "../common";
 
 /**
  * General handler context that is common to all handler methods.
+ *
+ * @experimental
  */
 export interface OperationContext {
-  /** Name of the service that contains the operation. */
+  /**
+   * Name of the service that contains the operation.
+   */
   readonly service: string;
 
-  /** Name of the operation. */
+  /**
+   * Name of the operation.
+   */
   readonly operation: string;
 
-  /** Request header fields. */
+  /**
+   * Request header fields.
+   */
   readonly headers: Record<string, string>;
 
-  /** Signaled when the current request is canceled. */
+  /**
+   * Signaled when the current request is canceled.
+   */
   readonly abortSignal: AbortSignal;
 }
 
 /**
- * Context for the {@link OperationHandler["start"]} method.
+ * Context for the {@link OperationHandler.start} method.
+ *
+ * @experimental
  */
 export interface StartOperationContext extends OperationContext {
   /**
@@ -54,24 +66,28 @@ export interface StartOperationContext extends OperationContext {
 }
 
 /**
- * Context for the {@link OperationHandler["getInfo"]} method.
+ * Context for the {@link OperationHandler.getInfo} method.
+ *
+ * @experimental
  */
 export type GetOperationInfoContext = OperationContext;
 
 /**
- * Context for the {@link OperationHandler["getResult"]} method.
+ * Context for the {@link OperationHandler.getResult} method.
+ *
+ * @experimental
  */
 export interface GetOperationResultContext extends OperationContext {
   /**
    * If specified and non-zero, reflects the duration (in milliseconds) the caller has indicated that it wants to wait
    * for operation completion, turning the request into a long poll.
-   *
-   * @experimental
    */
   readonly timeoutMs: number | undefined;
 }
 
 /**
- * Context for the {@link OperationHandler["cancel"]} method.
+ * Context for the {@link OperationHandler.cancel} method.
+ *
+ * @experimental
  */
 export type CancelOperationContext = OperationContext;

--- a/src/handler/operation-handler.ts
+++ b/src/handler/operation-handler.ts
@@ -9,6 +9,8 @@ import {
 
 /**
  * A handler for an operation.
+ *
+ * @experimental
  */
 export interface OperationHandler<I, O> {
   /**
@@ -27,21 +29,17 @@ export interface OperationHandler<I, O> {
    *
    * Throw an {@link OperationError} to indicate that an operation completed as failed or canceled.
    *
-   * When {@link GetOperationResultContext["wait"]} is greater than zero, this request should be treated as a long poll.
-   * Note that the specified wait duration may be longer than the configured client or server side request timeout, and
-   * should be handled separately.
+   * When {@link GetOperationResultContext.timeoutMs | timeoutMs} is greater than zero, this request should be treated
+   * as a long poll. Note that the specified wait duration may be longer than the configured client or server side
+   * request timeout, and should be handled separately.
    *
    * It is the implementor's responsiblity to respect the client's wait duration and return in a timely fashion, leaving
    * enough time for the request to complete and the response to be sent back.
-   *
-   * @experimental
    */
   getResult(ctx: GetOperationResultContext, token: string): Promise<O>;
 
   /**
    * GetInfo handles requests to get information about an asynchronous operation.
-   *
-   * @experimental
    */
   getInfo(ctx: GetOperationInfoContext, token: string): Promise<OperationInfo>;
 
@@ -57,7 +55,9 @@ export interface OperationHandler<I, O> {
 }
 
 /**
- * A shortcut for defining an operation handler that only implements the {@link OperationHandler["start"]} method and
+ * A shortcut for defining an operation handler that only implements the {@link OperationHandler.start} method and
  * always returns a {@link HandlerStartOperationResultSync}.
+ *
+ * @experimental
  */
 export type SyncOperationHandler<I, O> = (ctx: StartOperationContext, input: I) => Promise<O>;

--- a/src/handler/service-handler.ts
+++ b/src/handler/service-handler.ts
@@ -3,6 +3,8 @@ import { OperationHandler, SyncOperationHandler } from "./operation-handler";
 
 /**
  * A type that defines a handler for a given operation.
+ *
+ * @experimental
  */
 export type OperationHandlerFor<T> =
   T extends OperationDefinition<infer I, infer O>
@@ -11,13 +13,17 @@ export type OperationHandlerFor<T> =
 
 /**
  * A type that defines a collection of handlers for a given collection of operation interfaces.
+ *
+ * @experimental
  */
 export type ServiceHandlerFor<T extends OperationMap = OperationMap> = {
   [K in keyof T & string]: OperationHandlerFor<T[K]>;
 };
 
 /**
- * A {@link Service} that includes a collection of handlers for its operations.
+ * A Service that includes a collection of handlers for its operations.
+ *
+ * @experimental
  */
 export interface ServiceHandler<T extends OperationMap = OperationMap>
   extends ServiceDefinition<T> {
@@ -26,6 +32,8 @@ export interface ServiceHandler<T extends OperationMap = OperationMap>
 
 /**
  * Constructs a service handler for a given service contract.
+ *
+ * @experimental
  */
 export function serviceHandler<T extends OperationMap>(
   service: ServiceDefinition<T>,

--- a/src/handler/service-registry.ts
+++ b/src/handler/service-registry.ts
@@ -13,6 +13,8 @@ import { OperationHandler, SyncOperationHandler } from "./operation-handler";
 
 /**
  * A collection of service handlers that dispatches requests to the registered service and operation handler.
+ *
+ * @experimental
  */
 export class ServiceRegistry implements OperationHandler<unknown, unknown> {
   private services = new Map<
@@ -20,6 +22,9 @@ export class ServiceRegistry implements OperationHandler<unknown, unknown> {
     Map<string, OperationHandler<any, any> | SyncOperationHandler<any, any>>
   >();
 
+  /**
+   * @experimental
+   */
   constructor(services: ServiceHandler[]) {
     for (const s of services) {
       if (!s.name) {

--- a/src/handler/start-operation-result.ts
+++ b/src/handler/start-operation-result.ts
@@ -1,19 +1,28 @@
-/** A result that indicates that an operation completed successfully. */
+/**
+ * A result that indicates that an operation completed successfully.
+ *
+ * @experimental
+ */
 export interface HandlerStartOperationResultSync<T> {
   value: T;
 }
 
-/** A result that indicates that an operation has been accepted and will complete asynchronously. */
+/**
+ * A result that indicates that an operation has been accepted and will complete asynchronously.
+ *
+ * @experimental
+ */
 export interface HandlerStartOperationResultAsync {
   /**
-   * A token to identify the operation in followup handler methods such as {@link OperationHandler["getResult"]} and
-   * {@link OperationHandler["cancel"]}.
+   * A token to identify the operation in followup handler methods such as {@link OperationHandler.getResult}
+   * and {@link OperationHandler.cancel}.
    */
   token: string;
 }
-
 /**
- * The return type from the {@link OperationHandler["start"]}. May be synchronous or asynchronous.
+ * The return type from the {@link OperationHandler.start} method. May be synchronous or asynchronous.
+ *
+ * @experimental
  */
 export type HandlerStartOperationResult<T> =
   | HandlerStartOperationResultSync<T>

--- a/src/internal/object-utils.ts
+++ b/src/internal/object-utils.ts
@@ -6,6 +6,9 @@
  * @param fn - The mapper function.
  *
  * @returns A new object with the properties mapped to the new type.
+ *
+ * @internal
+ * @hidden
  */
 export function mapKeyValues<T extends Record<string, any>, U>(
   obj: T,

--- a/src/internal/symbol-instanceof.ts
+++ b/src/internal/symbol-instanceof.ts
@@ -22,6 +22,7 @@
  * checking for the presence of that symbol.
  *
  * @internal
+ * @hidden
  */
 export function injectSymbolBasedInstanceOf<E>(clazz: Class<E>, markerName: string): void {
   // It may seem redundant to have an explicit markerName argument here. Can't we simply use the class

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -5,6 +5,8 @@
  * in the type evaluation tree, which may sometime result in more readable type hints in editors.
  *
  * See https://github.com/sindresorhus/type-fest/blob/main/source/simplify.d.ts
+ *
+ * @internal
  */
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 
@@ -13,5 +15,7 @@ export type Simplify<T> = { [K in keyof T]: T[K] } & {};
  * without sacrificing auto-completion in TypeScript editors for the literal type part of the union.
  *
  * See https://github.com/sindresorhus/type-fest/blob/main/source/literal-union.d.ts
+ *
+ * @internal
  */
 export type LiteralStringUnion<T> = T | (string & {});

--- a/src/serialization/content.ts
+++ b/src/serialization/content.ts
@@ -2,6 +2,8 @@
  * A container for a map of headers and a byte array of data.
  *
  * It is used by the SDK's {@link Serializer} interface implementations.
+ *
+ * @experimental
  */
 export interface Content {
   /**

--- a/src/serialization/lazy-value.ts
+++ b/src/serialization/lazy-value.ts
@@ -4,8 +4,13 @@ import { Serializer } from "./serializer";
 /**
  * A container for a value encoded in an underlying stream.
  * It is used to stream inputs and outputs in the various client and server APIs.
+ *
+ * @experimental
  */
 export class LazyValue {
+  /**
+   * @experimental
+   */
   constructor(
     readonly serializer: Serializer,
 

--- a/src/serialization/serializer.ts
+++ b/src/serialization/serializer.ts
@@ -2,6 +2,8 @@ import { Content } from "./content";
 
 /**
  * Serializer is used by the framework to serialize/deserialize input and output.
+ *
+ * @experimental
  */
 export interface Serializer {
   /**

--- a/src/service/helpers.ts
+++ b/src/service/helpers.ts
@@ -5,6 +5,8 @@ import { OperationDefinition, ServiceDefinition } from "./service-definition";
 
 /**
  * Construct a service definition for a collection of operations.
+ *
+ * @experimental
  */
 export function service<Ops extends PartialOperationMap>(
   name: string,
@@ -24,6 +26,8 @@ export function service<Ops extends PartialOperationMap>(
 
 /**
  * Construct an operation definition as part of a service contract.
+ *
+ * @experimental
  */
 export function operation<I, O>(op?: OperationOptions<I, O>): PartialOperation<I, O> {
   return { ...op } as PartialOperation<I, O>;
@@ -31,6 +35,8 @@ export function operation<I, O>(op?: OperationOptions<I, O>): PartialOperation<I
 
 /**
  * Options for the {@link operation} function.
+ *
+ * @experimental
  */
 export interface OperationOptions<_I, _O> {
   name?: string;
@@ -38,11 +44,15 @@ export interface OperationOptions<_I, _O> {
 
 /**
  * A named collection of partial operation handlers. Input for the {@link service} function.
+ *
+ * @experimental
  */
 export type PartialOperationMap = Record<string, PartialOperation<any, any>>;
 
 /**
  * A type that transforms a {@link PartialOperationMap} into an {@link OperationMap}.
+ *
+ * @experimental
  */
 export type OperationMapFromPartial<T extends PartialOperationMap> = {
   [K in keyof T & string]: T[K] extends PartialOperation<infer I, infer O>
@@ -54,6 +64,8 @@ export type OperationMapFromPartial<T extends PartialOperationMap> = {
  * A partial {@link OperationDefinition} that is used to define an operation in a {@link ServiceDefinition}.
  *
  * The difference between this and {@link OperationDefinition} is that the name is optional.
+ *
+ * @experimental
  */
 export interface PartialOperation<I, O> {
   name?: string;

--- a/src/service/service-definition.ts
+++ b/src/service/service-definition.ts
@@ -5,6 +5,8 @@ export declare const outputBrand: unique symbol;
  * Definition of a Nexus service contract, including its name and operations.
  *
  * Can only be constructed by the {@link service} function.
+ *
+ * @experimental
  */
 export interface ServiceDefinition<Ops extends OperationMap = OperationMap> {
   name: string;
@@ -13,6 +15,8 @@ export interface ServiceDefinition<Ops extends OperationMap = OperationMap> {
 
 /**
  * An operation contract that describes the name, and input and output types of an operation.
+ *
+ * @experimental
  */
 export interface OperationDefinition<I, O> {
   name: string;
@@ -22,21 +26,29 @@ export interface OperationDefinition<I, O> {
 
 /**
  * A named collection of operations, as defined by a {@link ServiceDefinition}.
+ *
+ * @experimental
  */
 export type OperationMap = Record<string, OperationDefinition<any, any>>;
 
 /**
  * A mapped type that extracts the input type from an operation in a service.
+ *
+ * @experimental
  */
 export type OperationInput<T> = T extends OperationDefinition<infer I, any> ? I : any;
 
 /**
  * A mapped type that extracts the output type from an operation in a service.
+ *
+ * @experimental
  */
 export type OperationOutput<T> = T extends OperationDefinition<any, infer O> ? O : any;
 
 /**
  * A mapped type that extracts all operation names from a service.
+ *
+ * @experimental
  */
 export type OperationKey<T> = {
   [K in keyof T & string]: T[K] extends OperationDefinition<any, any> ? K : never;
@@ -48,6 +60,8 @@ export type OperationKey<T> = {
  * @param service - The service definition to validate.
  *
  * @throws {TypeError} If the service definition is invalid.
+ *
+ * @experimental
  */
 export function validateServiceDefinition(service: ServiceDefinition) {
   if (typeof service.name !== "string" || !service.name) {


### PR DESCRIPTION
## What changed

- Add `@experimental` tag in many places where it had been missed in previous PRs.
- Fix typedocs syntax in places where `build:docs` was producing errors.

## Notes to reviewers

These are pretty mechanical transformations. There should be nothing to discuss here.

