### PR TITLE
Complete work on HandlerStartOperationResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
     "build:docs": "typedoc src --plugin typedoc-github-theme",
-    "test": "node --test",
+    "test": "node --test --enable-source-maps",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
     "format": "prettier --check .",

--- a/src/handler/handler.test.ts
+++ b/src/handler/handler.test.ts
@@ -13,7 +13,7 @@ const myServiceHandler = nexus.serviceHandler(myService, {
   },
   fullOp: {
     async start(_ctx, input) {
-      return { value: input };
+      return nexus.HandlerStartOperationResult.sync(input);
     },
     async cancel(_ctx, _token) {
       //
@@ -34,7 +34,7 @@ describe("serviceHandler", () => {
     }
     fullOp: nexus.OperationHandler<number, number> = {
       async start(_ctx, input) {
-        return { value: input };
+        return nexus.HandlerStartOperationResult.sync(input);
       },
       async cancel(_ctx, _token) {
         //
@@ -113,12 +113,14 @@ describe("ServiceRegistry", () => {
     assert.deepEqual(
       await registry.start(mkStartCtx("service name", "syncOp"), createLazyValue("test")),
       {
+        isAsync: false,
         value: "test",
       },
     );
     assert.deepEqual(
       await registry.start(mkStartCtx("service name", "custom name"), createLazyValue(1)),
       {
+        isAsync: false,
         value: 1,
       },
     );

--- a/src/handler/handler.test.ts
+++ b/src/handler/handler.test.ts
@@ -112,17 +112,11 @@ describe("ServiceRegistry", () => {
   it("routes start to the correct handler", async () => {
     assert.deepEqual(
       await registry.start(mkStartCtx("service name", "syncOp"), createLazyValue("test")),
-      {
-        isAsync: false,
-        value: "test",
-      },
+      nexus.HandlerStartOperationResult.sync("test"),
     );
     assert.deepEqual(
       await registry.start(mkStartCtx("service name", "custom name"), createLazyValue(1)),
-      {
-        isAsync: false,
-        value: 1,
-      },
+      nexus.HandlerStartOperationResult.sync(1),
     );
   });
 

--- a/src/handler/index.ts
+++ b/src/handler/index.ts
@@ -7,9 +7,9 @@ export {
 } from "./operation-context";
 
 export {
+  HandlerStartOperationResult,
   type HandlerStartOperationResultSync,
   type HandlerStartOperationResultAsync,
-  type HandlerStartOperationResult,
 } from "./start-operation-result";
 
 export {

--- a/src/handler/service-registry.ts
+++ b/src/handler/service-registry.ts
@@ -81,7 +81,7 @@ export class ServiceRegistry implements OperationHandler<unknown, unknown> {
     const input = await lv.consume<any>();
     if (typeof handler === "function") {
       const value = await handler(ctx, input);
-      return { value };
+      return HandlerStartOperationResult.sync(value);
     }
     return await handler.start(ctx, input);
   }

--- a/src/handler/start-operation-result.test.ts
+++ b/src/handler/start-operation-result.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import { HandlerStartOperationResult } from "./start-operation-result";
+import assert from "node:assert";
+
+describe("StartOperationResult", () => {
+  it("Can be created as sync", () => {
+    const x = HandlerStartOperationResult.sync(42) as HandlerStartOperationResult;
+    if (x.isAsync) {
+      assert.fail("x.isAsync should be false");
+    } else {
+      assert.equal(x.value, 42);
+      // @ts-expect-error Property `token` doesn't exist
+      const _token = x.token;
+    }
+  });
+
+  it("Can be created as async", () => {
+    const x = HandlerStartOperationResult.async("token") as HandlerStartOperationResult;
+    if (x.isAsync) {
+      assert.equal(x.token, "token");
+      // @ts-expect-error Property `value` doesn't exist
+      const _value = x.value;
+    } else {
+      assert.fail("isAsync should be true");
+    }
+  });
+
+  it("Supports instanceof", () => {
+    const x: HandlerStartOperationResult = HandlerStartOperationResult.sync(42);
+    assert.ok(x instanceof HandlerStartOperationResult);
+
+    const y: HandlerStartOperationResult = HandlerStartOperationResult.async("token");
+    assert.ok(y instanceof HandlerStartOperationResult);
+
+    assert.ok(!((null as any) instanceof HandlerStartOperationResult));
+    assert.ok(!((undefined as any) instanceof HandlerStartOperationResult));
+    assert.ok(!(("" as any) instanceof HandlerStartOperationResult));
+    assert.ok(!((0 as any) instanceof HandlerStartOperationResult));
+    assert.ok(!(((() => undefined) as any) instanceof HandlerStartOperationResult));
+  });
+
+  it("Interface can't be implemented directly", () => {
+    // @ts-expect-error Property `__isHandlerStartOperationResultSymbol` doesn't exist
+    const _x: HandlerStartOperationResult = {
+      isAsync: false,
+      value: 42,
+    };
+
+    // @ts-expect-error Property `__isHandlerStartOperationResultSymbol` doesn't exist
+    const _y: HandlerStartOperationResult = {
+      isAsync: true,
+      token: "token",
+    };
+  });
+});

--- a/src/handler/start-operation-result.ts
+++ b/src/handler/start-operation-result.ts
@@ -1,9 +1,18 @@
 /** @import { OperationHandler } from "./operation-handler" */
 
 /**
- * The return type from the {@link OperationHandler.start} method. May be synchronous or asynchronous.
+ * An internal symbol, used to prevent direct implementation of interfaces.
  *
- * @see {@link HandlerStartOperationResult.sync} or {@link HandlerStartOperationResult.async}
+ * @hidden
+ * @internal
+ */
+const isHandlerStartOperationResultSymbol = Symbol("__nexus_isHandlerStartOperationResult");
+
+/**
+ * The return type from the {@link OperationHandler.start} method.
+ *
+ * Use either {@link HandlerStartOperationResult.sync} or {@link HandlerStartOperationResult.async}
+ * to create a result object. Do not implement this interface directly.
  *
  * @experimental
  */
@@ -12,7 +21,10 @@ export type HandlerStartOperationResult<T = unknown> =
   | HandlerStartOperationResultAsync;
 
 /**
- * The return type from the {@link OperationHandler.start} method. The result may be synchronous or asynchronous.
+ * The return type from the {@link OperationHandler.start} method.
+ *
+ * Use either {@link HandlerStartOperationResult.sync} or {@link HandlerStartOperationResult.async}
+ * to create a result object. Do not implement this interface directly.
  *
  * @experimental
  */
@@ -24,6 +36,7 @@ export const HandlerStartOperationResult = {
     return {
       isAsync: true,
       token,
+      [isHandlerStartOperationResultSymbol]: true,
     };
   },
 
@@ -34,12 +47,24 @@ export const HandlerStartOperationResult = {
     return {
       isAsync: false,
       value,
+      [isHandlerStartOperationResultSymbol]: true,
     };
+  },
+
+  [Symbol.hasInstance]: function (this: any, value: object): boolean {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      (value as any)[isHandlerStartOperationResultSymbol] === true
+    );
   },
 };
 
 /**
  * A result that indicates that an operation completed successfully.
+ *
+ * Use {@link HandlerStartOperationResult.sync} to create a sync result object.
+ * Do not implement this interface directly.
  *
  * @example
  * ```typescript
@@ -50,7 +75,8 @@ export const HandlerStartOperationResult = {
  */
 export interface HandlerStartOperationResultSync<T = unknown> {
   /**
-   * Indicate whether the operation will complete synchronously (false) or asynchronously (true).
+   * Indicate whether the operation completed synchronously (false) or will complete
+   * asynchronously (true).
    */
   isAsync: false;
 
@@ -58,10 +84,21 @@ export interface HandlerStartOperationResultSync<T = unknown> {
    * The return value of the operation.
    */
   value: T;
+
+  /**
+   * Prevents direct implementation of this interface.
+   *
+   * @hidden
+   * @internal
+   */
+  [isHandlerStartOperationResultSymbol]: true;
 }
 
 /**
  * A result that indicates that an operation has been accepted and will complete asynchronously.
+ *
+ * Use {@link HandlerStartOperationResult.async} to create an async result object.
+ * Do not implement this interface directly.
  *
  * @example
  * ```typescript
@@ -72,7 +109,8 @@ export interface HandlerStartOperationResultSync<T = unknown> {
  */
 export interface HandlerStartOperationResultAsync {
   /**
-   * Indicate whether the operation will complete synchronously (false) or asynchronously (true).
+   * Indicate whether the operation completed synchronously (false) or will complete
+   * asynchronously (true).
    */
   isAsync: true;
 
@@ -81,4 +119,12 @@ export interface HandlerStartOperationResultAsync {
    * and {@link OperationHandler.cancel}.
    */
   token: string;
+
+  /**
+   * Prevents direct implementation of this interface.
+   *
+   * @hidden
+   * @internal
+   */
+  [isHandlerStartOperationResultSymbol]: true;
 }

--- a/src/handler/start-operation-result.ts
+++ b/src/handler/start-operation-result.ts
@@ -1,29 +1,84 @@
+/** @import { OperationHandler } from "./operation-handler" */
+
 /**
- * A result that indicates that an operation completed successfully.
+ * The return type from the {@link OperationHandler.start} method. May be synchronous or asynchronous.
+ *
+ * @see {@link HandlerStartOperationResult.sync} or {@link HandlerStartOperationResult.async}
  *
  * @experimental
  */
-export interface HandlerStartOperationResultSync<T> {
+export type HandlerStartOperationResult<T = unknown> =
+  | HandlerStartOperationResultSync<T>
+  | HandlerStartOperationResultAsync;
+
+/**
+ * The return type from the {@link OperationHandler.start} method. The result may be synchronous or asynchronous.
+ *
+ * @experimental
+ */
+export const HandlerStartOperationResult = {
+  /**
+   * Create a result that indicates that an operation has been accepted and will complete asynchronously.
+   */
+  async(token: string): HandlerStartOperationResultAsync {
+    return {
+      isAsync: true,
+      token,
+    };
+  },
+
+  /**
+   * Create a result that indicates that an operation completed successfully.
+   */
+  sync<T>(value: T): HandlerStartOperationResultSync<T> {
+    return {
+      isAsync: false,
+      value,
+    };
+  },
+};
+
+/**
+ * A result that indicates that an operation completed successfully.
+ *
+ * @example
+ * ```typescript
+ *   return HandlerStartOperationResult.sync(42);
+ * ```
+ *
+ * @experimental
+ */
+export interface HandlerStartOperationResultSync<T = unknown> {
+  /**
+   * Indicate whether the operation will complete synchronously (false) or asynchronously (true).
+   */
+  isAsync: false;
+
+  /**
+   * The return value of the operation.
+   */
   value: T;
 }
 
 /**
  * A result that indicates that an operation has been accepted and will complete asynchronously.
  *
+ * @example
+ * ```typescript
+ *   return HandlerStartOperationResult.async("unique token");
+ * ```
+ *
  * @experimental
  */
 export interface HandlerStartOperationResultAsync {
+  /**
+   * Indicate whether the operation will complete synchronously (false) or asynchronously (true).
+   */
+  isAsync: true;
+
   /**
    * A token to identify the operation in followup handler methods such as {@link OperationHandler.getResult}
    * and {@link OperationHandler.cancel}.
    */
   token: string;
 }
-/**
- * The return type from the {@link OperationHandler.start} method. May be synchronous or asynchronous.
- *
- * @experimental
- */
-export type HandlerStartOperationResult<T> =
-  | HandlerStartOperationResultSync<T>
-  | HandlerStartOperationResultAsync;


### PR DESCRIPTION
## What changed

This is all about `HandlerStartOperationResult`:
- Add an `isAsync` discriminant property on `HandlerStartOperationResult` to differentiate between the sync and async variants.
- Add helper factory methods `HandlerStartOperationResult.sync` and `HandlerStartOperationResult.async`.
- Typedocs.
