### PR TITLE
[2] Add default serializers and serializer type hints

### DIFF
--- a/src/serialization/index.ts
+++ b/src/serialization/index.ts
@@ -1,3 +1,23 @@
-export { LazyValue } from "./lazy-value";
-export { type Serializer } from "./serializer";
-export { type Content } from "./content";
+export {
+  //
+  type Serializer,
+} from "./serializer";
+
+export {
+  defaultSerializers,
+  CompositeSerializer,
+  IncompatibleSerializerError,
+  NullSerializer,
+  JsonSerializer,
+  BinarySerializer,
+} from "./serializers";
+
+export {
+  //
+  type Content,
+} from "./content";
+
+export {
+  //
+  LazyValue,
+} from "./lazy-value";

--- a/src/serialization/serializer.ts
+++ b/src/serialization/serializer.ts
@@ -1,18 +1,31 @@
 import { Content } from "./content";
 
 /**
- * Serializer is used by the framework to serialize/deserialize input and output.
+ * Provides is used by the framework to serialize and deserialize an operation's input and output.
  *
  * @experimental
  */
 export interface Serializer {
   /**
    * Serialize encodes a value into a {@link Content}.
+   *
+   * @param value - The value to serialize.
+   * @param typeHint - The corresponding type hint specified on the operation definition, if any.
+   *                   Type hints may be used to provide guidance to the serializer (e.g. to specify
+   *                   the expected JSON schema, the Protobuf message type, etc).
+   *
+   * The Nexus RPC SDK itself does not support type hints, and does not specify the nature of type
+   * hints.
    */
-  serialize(value: unknown): Content;
+  serialize(value: unknown, typeHint?: unknown): Content;
 
   /**
    * Deserialize decodes a {@link Content} into a value.
+   *
+   * @param content - The content to deserialize.
+   * @param typeHint - The corresponding type hint specified on the operation definition, if any.
+   *                   Type hints may be used to provide guidance to the serializer (e.g. to specify
+   *                   the expected JSON schema, the Protobuf message type, etc).
    */
-  deserialize<T = unknown>(content: Content): T;
+  deserialize<T = unknown>(content: Content, typeHint?: unknown): T;
 }

--- a/src/serialization/serializers.test.ts
+++ b/src/serialization/serializers.test.ts
@@ -1,0 +1,64 @@
+import { it, describe } from "node:test";
+import * as assert from "node:assert/strict";
+import { defaultSerializers } from "./serializers";
+
+describe("Default Serializers", () => {
+  it("Correctly serializes and deserializes 'undefined'", () => {
+    const content = defaultSerializers.serialize(undefined);
+    assert.equal(content.headers["content-type"], undefined);
+    assert.equal(content.data, undefined);
+
+    const value = defaultSerializers.deserialize(content);
+    assert.equal(value, undefined);
+  });
+
+  it("Correctly serializes and deserializes 'null'", () => {
+    const content = defaultSerializers.serialize(null);
+    assert.equal(content.headers["content-type"], undefined);
+    assert.equal(content.data, undefined);
+
+    // Note here that the Null serializer is not strictly symmetric:
+    // both `null` and `undefined` ends up being deserialized to `undefined`.
+    const value = defaultSerializers.deserialize(content);
+    assert.equal(value, undefined);
+  });
+
+  it("Correctly serializes and deserializes a Uint8Array", () => {
+    const originalBuffer = new Uint8Array([1, 2, 3]);
+
+    const content = defaultSerializers.serialize(originalBuffer);
+    assert.equal(content.headers["content-type"], "application/octet-stream");
+    assert.deepEqual(content.data, originalBuffer);
+
+    const value = defaultSerializers.deserialize(content);
+    assert.deepEqual(value, originalBuffer);
+  });
+
+  it("Correctly serializes and deserializes a simple string", () => {
+    const originalString = "Hello, world!";
+
+    const content = defaultSerializers.serialize(originalString);
+    assert.equal(content.headers["content-type"], "application/json");
+    assert.deepEqual(content.data, Buffer.from(JSON.stringify(originalString)));
+
+    const value = defaultSerializers.deserialize(content);
+    assert.equal(value, originalString);
+  });
+
+  it("Correctly serializes and deserializes a plain object", () => {
+    const originalValue = {
+      a: "Hello, world!",
+      b: {
+        c: [1, 2, 3],
+        d: true,
+      },
+    };
+
+    const content = defaultSerializers.serialize(originalValue);
+    assert.equal(content.headers["content-type"], "application/json");
+    assert.deepEqual(content.data, Buffer.from(JSON.stringify(originalValue)));
+
+    const value = defaultSerializers.deserialize(content);
+    assert.deepEqual(value, originalValue);
+  });
+});

--- a/src/serialization/serializers.ts
+++ b/src/serialization/serializers.ts
@@ -1,0 +1,145 @@
+import { injectSymbolBasedInstanceOf } from "../internal/symbol-instanceof";
+import { Content } from "./content";
+import { Serializer } from "./serializer";
+
+/**
+ * A {@link Serializer} that composes multiple serializers together.
+ *
+ * During serialization, each serializer is tried in sequence until one succeeds to serialize the
+ * given value. During deserialization, each serializer is tried in reverse sequence until one
+ * succeeds to deserialize the given {@link Content}.
+ *
+ * Child serializers must throw an {@link IncompatibleSerializerError} to indicate that they
+ * cannot serialize or deserialize the given value or {@link Content}. Any other error type
+ * (e.g. one that would be caused by a validation error) will immediately stop the sequence and be
+ * propagated to the caller.
+ *
+ * If no serializer was able to serialize or deserialize the value or content, the
+ * `CompositeSerializer` itself throws an {@link IncompatibleSerializerError}.
+ *
+ * @experimental
+ */
+export class CompositeSerializer implements Serializer {
+  constructor(private readonly serializers: Serializer[]) {}
+
+  serialize(value: unknown, typeHint?: unknown): Content {
+    for (const serializer of this.serializers) {
+      try {
+        return serializer.serialize(value, typeHint);
+      } catch (error) {
+        if (error instanceof IncompatibleSerializerError) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+
+  deserialize<T = unknown>(content: Content, typeHint?: unknown): T {
+    for (const serializer of this.serializers) {
+      try {
+        return serializer.deserialize(content, typeHint);
+      } catch (error) {
+        if (error instanceof IncompatibleSerializerError) {
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+}
+
+/**
+ * An error to be thrown by a {@link Serializer} if it is unable to serialize a given value, or
+ * deserialize a given {@link Content}.
+ *
+ * This error type is only a convenience. Implementors may alternatively choose to throw any other
+ * error in that case, instead of this specific error,
+ *
+ * @experimental
+ */
+export class IncompatibleSerializerError extends Error {}
+injectSymbolBasedInstanceOf(IncompatibleSerializerError, "IncompatibleSerializerError");
+
+/**
+ * @experimental
+ */
+export class NullSerializer implements Serializer {
+  serialize(value: unknown, _typeHint?: unknown): Content {
+    if (value == null) {
+      return { headers: {}, data: undefined };
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+
+  deserialize<T = unknown>(content: Content, _typeHint?: unknown): T {
+    if (content.data == null) {
+      return undefined as T;
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+}
+
+/**
+ * @experimental
+ */
+export class JsonSerializer implements Serializer {
+  serialize(value: unknown, _typeHint?: unknown): Content {
+    return {
+      headers: {
+        "content-type": "application/json",
+      },
+      data: Buffer.from(JSON.stringify(value)),
+    };
+  }
+
+  deserialize<T = unknown>(content: Content, _typeHint?: unknown): T {
+    const type = content.headers["content-type"];
+    const data = content.data;
+
+    if (type === "application/json" && data != null) {
+      return JSON.parse(Buffer.from(data).toString("utf-8")) as T;
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+}
+
+/**
+ * @experimental
+ */
+export class BinarySerializer implements Serializer {
+  serialize(value: unknown, _typeHint?: unknown): Content {
+    if (value instanceof Uint8Array) {
+      return { headers: { "content-type": "application/octet-stream" }, data: value };
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+
+  deserialize<T = unknown>(content: Content, _typeHint?: unknown): T {
+    const type = content.headers["content-type"];
+    const data = content.data;
+
+    if (type === "application/octet-stream" && data != null) {
+      return data as T;
+    }
+
+    throw new IncompatibleSerializerError();
+  }
+}
+
+/**
+ * @experimental
+ */
+export const defaultSerializers: Serializer = new CompositeSerializer([
+  new NullSerializer(),
+  new BinarySerializer(),
+  new JsonSerializer(),
+]);

--- a/src/service/helpers.ts
+++ b/src/service/helpers.ts
@@ -39,7 +39,33 @@ export function operation<I, O>(op?: OperationOptions<I, O>): PartialOperation<I
  * @experimental
  */
 export interface OperationOptions<_I, _O> {
+  /**
+   * The name of the operation.
+   *
+   * If not provided, the name of the operation will be the name of the property representing that
+   * operation in the service definition.
+   */
   name?: string;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * input of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the input.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  inputTypeHint?: unknown;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * output of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the output.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  outputTypeHint?: unknown;
 }
 
 /**
@@ -69,6 +95,38 @@ export type OperationMapFromPartial<T extends PartialOperationMap> = {
  */
 export interface PartialOperation<I, O> {
   name?: string;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * input of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the input.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  inputTypeHint?: unknown;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * output of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the output.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  outputTypeHint?: unknown;
+
+  /**
+   * @see {@link inputBrand}
+   * @internal
+   * @hidden
+   */
   [inputBrand]: I;
+
+  /**
+   * @see {@link outputBrand}
+   * @internal
+   * @hidden
+   */
   [outputBrand]: O;
 }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -5,6 +5,7 @@ export {
   type OperationInput,
   type OperationOutput,
   type OperationKey,
+  validateServiceDefinition,
 } from "./service-definition";
 
 export {

--- a/src/service/service-definition.ts
+++ b/src/service/service-definition.ts
@@ -1,6 +1,3 @@
-export declare const inputBrand: unique symbol;
-export declare const outputBrand: unique symbol;
-
 /**
  * Definition of a Nexus service contract, including its name and operations.
  *
@@ -19,10 +16,63 @@ export interface ServiceDefinition<Ops extends OperationMap = OperationMap> {
  * @experimental
  */
 export interface OperationDefinition<I, O> {
+  /**
+   * The name of the operation.
+   */
   name: string;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * input of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the input.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  inputTypeHint?: unknown;
+
+  /**
+   * A type hint that will be provided to the serializer when serializing and deserializing the
+   * output of this operation. It can be used for example, to indicate the expected JSON schema or
+   * Protobuf message type of the output.
+   *
+   * The nature of type hints depends on the serializer used. The default serializers provided by
+   * the Nexus RPC SDK do not expect nor use any type hints.
+   */
+  outputTypeHint?: unknown;
+
+  /**
+   * @see {@link inputBrand}
+   * @internal
+   * @hidden
+   */
   [inputBrand]: I;
+
+  /**
+   * @see {@link outputBrand}
+   * @internal
+   * @hidden
+   */
   [outputBrand]: O;
 }
+
+/**
+ * A type marker used to preserve type safety on the input type of an operation.
+ * This really only exists at the type level. It is not used at runtime.
+ *
+ * @internal
+ * @hidden
+ */
+export declare const inputBrand: unique symbol;
+
+/**
+ * A type marker used to preserve type safety on the output type of an operation.
+ * This really only exists at the type level. It is not used at runtime.
+ *
+ * @internal
+ * @hidden
+ */
+export declare const outputBrand: unique symbol;
 
 /**
  * A named collection of operations, as defined by a {@link ServiceDefinition}.


### PR DESCRIPTION
## What changed

- Added default serializers: `CompositeSerializer`, `NullSerializer`, `BinarySerializer` and `JsonSerializer`.
- `ServiceRegistry` now owns the serializer, receiving it as part of the `ServiceRegistry` initialization, rather than the serializer being somehow attached to each `LazyValue`.
- Operation response value are now serialized appropriately.
- Added "type hints" for an Operation's input and output; these type hints are passed to serializers. The Nexus SDK itself do not use those type hints, nor mandate the specific nature of those type hints.