### PR TITLE
Add REQUEST_TIMEOUT and CONFLICT handler error types

### DIFF
--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -157,7 +157,7 @@ export const HandlerErrorType = {
    * Returned by the server when it has given up handling a request. This may occur by enforcing
    * a client provided `Request-Timeout` or for any arbitrary reason such as enforcing some
    * configurable limit.
-   * 
+   *
    * Subsequent requests by the client are permissible.
    */
   REQUEST_TIMEOUT: "REQUEST_TIMEOUT",
@@ -165,7 +165,7 @@ export const HandlerErrorType = {
   /**
    * The request could not be made due to a conflict. This may happen when trying to create an
    * operation that has already been started.
-   * 
+   *
    * Clients should not retry this request unless advised otherwise.
    */
   CONFLICT: "CONFLICT",

--- a/src/common/handler-error.ts
+++ b/src/common/handler-error.ts
@@ -78,12 +78,14 @@ export class HandlerError extends Error {
       case "UNAUTHORIZED":
       case "NOT_FOUND":
       case "NOT_IMPLEMENTED":
+      case "CONFLICT":
         return false;
 
       case "UNAVAILABLE":
       case "UPSTREAM_TIMEOUT":
       case "RESOURCE_EXHAUSTED":
       case "INTERNAL":
+      case "REQUEST_TIMEOUT":
         return true;
 
       default: {
@@ -150,6 +152,23 @@ export const HandlerErrorType = {
    * The requested resource could not be found but may be available in the future.
    */
   NOT_FOUND: "NOT_FOUND",
+
+  /**
+   * Returned by the server when it has given up handling a request. This may occur by enforcing
+   * a client provided `Request-Timeout` or for any arbitrary reason such as enforcing some
+   * configurable limit.
+   * 
+   * Subsequent requests by the client are permissible.
+   */
+  REQUEST_TIMEOUT: "REQUEST_TIMEOUT",
+
+  /**
+   * The request could not be made due to a conflict. This may happen when trying to create an
+   * operation that has already been started.
+   * 
+   * Clients should not retry this request unless advised otherwise.
+   */
+  CONFLICT: "CONFLICT",
 
   /**
    * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system


### PR DESCRIPTION
## Description

This PR adds two new handler error types to the Nexus RPC TypeScript SDK as required by the updated Nexus RPC specification:

- **REQUEST_TIMEOUT**: Returned by the server when it has given up handling a request. This may occur by enforcing a client-provided `Request-Timeout` or for any arbitrary reason such as enforcing some configurable limit. Subsequent requests by the client are permissible.

- **CONFLICT**: The request could not be made due to a conflict. This may happen when trying to create an operation that has already been started. Clients should not retry this request unless advised otherwise.

Fix #23.

## Changes Made

1. Added `REQUEST_TIMEOUT` to the `HandlerErrorType` enum with appropriate documentation
2. Added `CONFLICT` to the `HandlerErrorType` enum with appropriate documentation  
3. Updated the retry logic in the `retryable` getter:
   - `REQUEST_TIMEOUT` is retryable by default
   - `CONFLICT` is non-retryable by default

## Reference

These changes align with the corresponding updates made to the Go SDK and follow the Nexus RPC specification requirements.