### PR TITLE
feat: add operation type information

### DIFF
--- a/src/handler/service-handler.test.ts
+++ b/src/handler/service-handler.test.ts
@@ -4,7 +4,11 @@ import * as nexus from "../index";
 
 const myService = nexus.service("service name", {
   syncOp: nexus.operation<string, string>(),
-  fullOp: nexus.operation<number, number>({ name: "custom name" }),
+  fullOp: nexus.operation<number, number>({
+    name: "custom name",
+    inputType: { converterHint: { converter: "input" } },
+    outputType: { converterHint: { converter: "output" } },
+  }),
 });
 
 const myServiceOpsHandler: nexus.ServiceHandlerFor<(typeof myService)["operations"]> = {
@@ -40,6 +44,14 @@ describe("ServiceHandler", () => {
     const serviceHandler = nexus.serviceHandler(myService, myServiceOpsHandler);
     assert.equal(serviceHandler.getOperationHandler("syncOp").name, "syncOp");
     assert.equal(serviceHandler.getOperationHandler("custom name" as any).name, "custom name");
+    assert.equal(
+      serviceHandler.getOperationHandler("custom name" as any).inputType?.converterHint?.converter,
+      "input",
+    );
+    assert.equal(
+      serviceHandler.getOperationHandler("custom name" as any).outputType?.converterHint?.converter,
+      "output",
+    );
   });
 
   it("Can be constructed with a class", () => {

--- a/src/handler/service-handler.test.ts
+++ b/src/handler/service-handler.test.ts
@@ -6,8 +6,8 @@ const myService = nexus.service("service name", {
   syncOp: nexus.operation<string, string>(),
   fullOp: nexus.operation<number, number>({
     name: "custom name",
-    inputType: { converterHint: { converter: "input" } },
-    outputType: { converterHint: { converter: "output" } },
+    inputType: { payloadConverterHint: { converter: "input" } },
+    outputType: { payloadConverterHint: { converter: "output" } },
   }),
 });
 
@@ -45,11 +45,13 @@ describe("ServiceHandler", () => {
     assert.equal(serviceHandler.getOperationHandler("syncOp").name, "syncOp");
     assert.equal(serviceHandler.getOperationHandler("custom name" as any).name, "custom name");
     assert.equal(
-      serviceHandler.getOperationHandler("custom name" as any).inputType?.converterHint?.converter,
+      serviceHandler.getOperationHandler("custom name" as any).inputType?.payloadConverterHint
+        ?.converter,
       "input",
     );
     assert.equal(
-      serviceHandler.getOperationHandler("custom name" as any).outputType?.converterHint?.converter,
+      serviceHandler.getOperationHandler("custom name" as any).outputType?.payloadConverterHint
+        ?.converter,
       "output",
     );
   });

--- a/src/service/helpers.ts
+++ b/src/service/helpers.ts
@@ -2,6 +2,7 @@ import { mapKeyValues } from "../internal/object-utils";
 import { Simplify } from "../internal/types";
 import { inputBrand, outputBrand, validateServiceDefinition } from "./service-definition";
 import { OperationDefinition, ServiceDefinition } from "./service-definition";
+import type { TypeInfo } from "./type-info";
 
 /**
  * Construct a service definition for a collection of operations.
@@ -40,6 +41,8 @@ export function operation<I, O>(op?: OperationOptions<I, O>): PartialOperation<I
  */
 export interface OperationOptions<_I, _O> {
   name?: string;
+  inputType?: TypeInfo<_I, unknown>;
+  outputType?: TypeInfo<_O, unknown>;
 }
 
 /**
@@ -69,6 +72,8 @@ export type OperationMapFromPartial<T extends PartialOperationMap> = {
  */
 export interface PartialOperation<I, O> {
   name?: string;
+  inputType?: TypeInfo<I, unknown>;
+  outputType?: TypeInfo<O, unknown>;
   [inputBrand]: I;
   [outputBrand]: O;
 }

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -7,6 +7,8 @@ export {
   type OperationKey,
 } from "./service-definition";
 
+export { type TypeInfo, type TransferTypeConverter, type ConverterHint } from "./type-info";
+
 export {
   service,
   operation,

--- a/src/service/service-definition.ts
+++ b/src/service/service-definition.ts
@@ -1,3 +1,5 @@
+import type { TypeInfo } from "./type-info";
+
 export declare const inputBrand: unique symbol;
 export declare const outputBrand: unique symbol;
 
@@ -20,6 +22,8 @@ export interface ServiceDefinition<Ops extends OperationMap = OperationMap> {
  */
 export interface OperationDefinition<I, O> {
   name: string;
+  inputType?: TypeInfo<I, unknown>;
+  outputType?: TypeInfo<O, unknown>;
   [inputBrand]: I;
   [outputBrand]: O;
 }

--- a/src/service/service.test.ts
+++ b/src/service/service.test.ts
@@ -2,27 +2,31 @@ import { it, describe } from "node:test";
 import * as assert from "node:assert/strict";
 import * as nexus from "../index";
 
+const inputType: nexus.TypeInfo<number, string> = {
+  transferTypeConverter: {
+    fromTransferType: (value) => Number(value),
+    toTransferType: (value) => String(value),
+  },
+  payloadConverterHint: { converter: "input" },
+};
+
+const outputType: nexus.TypeInfo<number> = {
+  payloadConverterHint: { converter: "output" },
+};
+
 const myService = nexus.service("service name", {
   syncOp: nexus.operation<string, string>(),
   fullOp: nexus.operation<number, number>({
     name: "custom name",
-    inputType: {
-      converterHint: { converter: "input" },
-    },
-    outputType: {
-      converterHint: { converter: "output" },
-    },
+    inputType,
+    outputType,
   }),
 });
 
 describe("service and operation", () => {
   it("preserves operation type information", () => {
-    assert.deepEqual(myService.operations.fullOp.inputType, {
-      converterHint: { converter: "input" },
-    });
-    assert.deepEqual(myService.operations.fullOp.outputType, {
-      converterHint: { converter: "output" },
-    });
+    assert.strictEqual(myService.operations.fullOp.inputType, inputType);
+    assert.strictEqual(myService.operations.fullOp.outputType, outputType);
   });
 
   it("throws when registering a service with an empty name", () => {

--- a/src/service/service.test.ts
+++ b/src/service/service.test.ts
@@ -2,13 +2,29 @@ import { it, describe } from "node:test";
 import * as assert from "node:assert/strict";
 import * as nexus from "../index";
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const myService = nexus.service("service name", {
   syncOp: nexus.operation<string, string>(),
-  fullOp: nexus.operation<number, number>({ name: "custom name" }),
+  fullOp: nexus.operation<number, number>({
+    name: "custom name",
+    inputType: {
+      converterHint: { converter: "input" },
+    },
+    outputType: {
+      converterHint: { converter: "output" },
+    },
+  }),
 });
 
 describe("service and operation", () => {
+  it("preserves operation type information", () => {
+    assert.deepEqual(myService.operations.fullOp.inputType, {
+      converterHint: { converter: "input" },
+    });
+    assert.deepEqual(myService.operations.fullOp.outputType, {
+      converterHint: { converter: "output" },
+    });
+  });
+
   it("throws when registering a service with an empty name", () => {
     assert.throws(
       () => nexus.service("", {}),

--- a/src/service/type-info.ts
+++ b/src/service/type-info.ts
@@ -1,0 +1,55 @@
+/**
+ * Describes how SDK conversion helpers adapt an application value of type `T` for payload conversion.
+ *
+ * {@link transferTypeConverter} performs an application-defined, payload-converter-independent transformation.
+ * For example, it can convert a class instance into a plain object before JSON serialization.
+ *
+ * {@link converterHint} carries metadata for a specific payload converter and describes its value type `D`.
+ * For example, a Protobuf converter hint can identify the message type required to deserialize bytes.
+ *
+ * On encoding, transfer type conversion runs before payload conversion. On decoding, payload conversion runs before
+ * transfer type conversion. Either mechanism may be used independently or they may be combined.
+ *
+ * SDK conversion helpers apply this information when supplied. Calling a payload converter directly does not.
+ *
+ * @experimental
+ */
+export interface TypeInfo<T = unknown, D = T> {
+  /**
+   * Converts between the application value and a representation suitable for payload conversion.
+   *
+   * This transformation runs outside the payload converter and should not depend on its serialization format.
+   */
+  transferTypeConverter?: TransferTypeConverter<T>;
+
+  /**
+   * Metadata forwarded unchanged to the payload converter.
+   *
+   * Use this when conversion requires format-specific runtime information, such as a Protobuf message type.
+   */
+  converterHint?: ConverterHint<D>;
+}
+
+/**
+ * Converts between an application value and its payload-converter-independent transfer representation.
+ *
+ * @experimental
+ */
+export interface TransferTypeConverter<T> {
+  fromTransferType(value: unknown): T;
+  toTransferType(value: T): unknown;
+}
+
+declare const valueTypeBrand: unique symbol;
+
+/**
+ * Identifies converter-specific metadata and associates it with the value type `T` handled by that converter.
+ *
+ * Extend this interface to define metadata for a payload converter.
+ *
+ * @experimental
+ */
+export interface ConverterHint<T = unknown> {
+  converter: string;
+  [valueTypeBrand]?: T;
+}

--- a/src/service/type-info.ts
+++ b/src/service/type-info.ts
@@ -4,13 +4,15 @@
  * {@link transferTypeConverter} performs an application-defined, payload-converter-independent transformation.
  * For example, it can convert a class instance into a plain object before JSON serialization.
  *
- * {@link converterHint} carries metadata for a specific payload converter and describes its value type `D`.
+ * {@link payloadConverterHint} carries metadata for a specific payload converter and describes its value type `D`.
  * For example, a Protobuf converter hint can identify the message type required to deserialize bytes.
  *
  * On encoding, transfer type conversion runs before payload conversion. On decoding, payload conversion runs before
  * transfer type conversion. Either mechanism may be used independently or they may be combined.
  *
- * SDK conversion helpers apply this information when supplied. Calling a payload converter directly does not.
+ * When {@link transferTypeConverter} is unspecified, `D` should be the same type as `T`.
+ *
+ * SDK conversion helpers apply this information when supplied. Calling a {@link PayloadConverter} directly does not.
  *
  * @experimental
  */
@@ -20,30 +22,32 @@ export interface TypeInfo<T = unknown, D = T> {
    *
    * This transformation runs outside the payload converter and should not depend on its serialization format.
    */
-  transferTypeConverter?: TransferTypeConverter<T>;
+  transferTypeConverter?: TransferTypeConverter<T, D>;
 
   /**
    * Metadata forwarded unchanged to the payload converter.
    *
    * Use this when conversion requires format-specific runtime information, such as a Protobuf message type.
    */
-  converterHint?: ConverterHint<D>;
+  payloadConverterHint?: ConverterHint<D>;
 }
 
 /**
- * Converts between an application value and its payload-converter-independent transfer representation.
+ * Converts between an application value of type `T` and its payload-converter-independent representation of type `D`.
  *
  * @experimental
  */
-export interface TransferTypeConverter<T> {
-  fromTransferType(value: unknown): T;
-  toTransferType(value: T): unknown;
+export interface TransferTypeConverter<T, D = unknown> {
+  fromTransferType(value: D): T;
+  toTransferType(value: T): D;
 }
 
 declare const valueTypeBrand: unique symbol;
 
 /**
  * Identifies converter-specific metadata and associates it with the value type `T` handled by that converter.
+ *
+ * The association applies to an individual payload conversion; it does not bind a payload converter instance to `T`.
  *
  * Extend this interface to define metadata for a payload converter.
  *


### PR DESCRIPTION
## What changed

Nexus operation definitions currently describe their TypeScript input and output types, but they cannot carry the runtime type information an SDK needs at serialization boundaries. This adds structurally compatible experimental `TypeInfo`, `TransferTypeConverter`, and `ConverterHint` contracts and lets operations provide `inputType` and `outputType` metadata.

Service construction now preserves that metadata through to operation handlers. Before this change, downstream SDKs had no definition-supplied information for reconstructing type-rich operation inputs and outputs. After it, they can apply transfer conversion and payload-converter hints using the operation definition.

Existing operation definitions remain unchanged when no type information is supplied.

## Validation

- TypeScript build
- All 30 tests
- ESLint
- Prettier
